### PR TITLE
sunxi: power: enable DLDO1 switch as well

### DIFF
--- a/plat/sun50iw1p1/bl31_sunxi_setup.c
+++ b/plat/sun50iw1p1/bl31_sunxi_setup.c
@@ -251,6 +251,7 @@ void bl31_platform_setup(void)
 	switch (socid) {
 	case 0x1689:
 		sunxi_pmic_setup();
+		sunxi_setup_ext_devices_a64();
 		break;
 	case 0x1718:
 		break;

--- a/plat/sun50iw1p1/platform.mk
+++ b/plat/sun50iw1p1/platform.mk
@@ -50,5 +50,6 @@ BL31_SOURCES		+=	drivers/arm/gic/arm_gic.c		\
 				plat/sun50iw1p1/plat_topology.c		\
 				plat/sun50iw1p1/aarch64/plat_helpers.S	\
 				plat/sun50iw1p1/sunxi_clocks.c		\
-				plat/sun50iw1p1/aarch64/sunxi_common.c
+				plat/sun50iw1p1/aarch64/sunxi_common.c	\
+				plat/sun50iw1p1/sunxi_ext_devices.c
 

--- a/plat/sun50iw1p1/sunxi_clocks.c
+++ b/plat/sun50iw1p1/sunxi_clocks.c
@@ -49,16 +49,16 @@ int sunxi_setup_clocks(uint16_t socid)
 	if ((reg & 0x0fffffff) != 0x1010) {		/* if not at 816 MHz: */
 		/* switch CPU to 24 MHz source for changing PLL1 */
 		mmio_write_32(CCMU_CPUX_AXI_CFG_REG,  0x00010000);
-		udelay(1);
+		udelay(10);
 
 		/* Set to 816 MHz */
 		mmio_write_32(CCMU_PLL_CPUX_CTRL_REG, 0x80001010);
-		udelay(1);
+		udelay(10);
 	}
 
 	/* switch CPU to PLL1 source, AXI = CPU/3, APB = CPU/4 */
 	mmio_write_32(CCMU_CPUX_AXI_CFG_REG,  0x00020302);
-	udelay(1);
+	udelay(10);
 
 	} else {
 		NOTICE("PLL_CPUX: %x\n", reg);

--- a/plat/sun50iw1p1/sunxi_clocks.c
+++ b/plat/sun50iw1p1/sunxi_clocks.c
@@ -45,7 +45,6 @@ int sunxi_setup_clocks(uint16_t socid)
 	/* Check initial CPU frequency: */
 	reg = mmio_read_32(CCMU_PLL_CPUX_CTRL_REG);
 
-	if (socid == 0x1689) {
 	if ((reg & 0x0fffffff) != 0x1010) {		/* if not at 816 MHz: */
 		/* switch CPU to 24 MHz source for changing PLL1 */
 		mmio_write_32(CCMU_CPUX_AXI_CFG_REG,  0x00010000);
@@ -59,10 +58,6 @@ int sunxi_setup_clocks(uint16_t socid)
 	/* switch CPU to PLL1 source, AXI = CPU/3, APB = CPU/4 */
 	mmio_write_32(CCMU_CPUX_AXI_CFG_REG,  0x00020302);
 	udelay(10);
-
-	} else {
-		NOTICE("PLL_CPUX: %x\n", reg);
-	}
 
 	/* AHB1 = PERIPH0 / (3 * 1) = 200MHz, APB1 = AHB1 / 2 */
 	mmio_write_32(CCMU_AHB1_APB1_CFG_REG, 0x00003180);

--- a/plat/sun50iw1p1/sunxi_def.h
+++ b/plat/sun50iw1p1/sunxi_def.h
@@ -37,6 +37,10 @@
 #define GICD_BASE			0x01c81000
 #define GICC_BASE			0x01c82000
 
+#define R_PRCM_BASE			0x1f01400
+#define R_TWI_BASE			0x1f02400
+#define R_PIO_BASE			0x1f02c00
+
 /* Firmware Image Package */
 #define FIP_IMAGE_NAME			"fip.bin"
 #define SUNXI_PRIMARY_CPU			0x0

--- a/plat/sun50iw1p1/sunxi_ext_devices.c
+++ b/plat/sun50iw1p1/sunxi_ext_devices.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016, Icenowy Zheng <icenowy@aosc.xyz> All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <mmio.h>
+#include "sunxi_def.h"
+#include "sunxi_private.h"
+
+void sunxi_setup_ext_devices_a64(void)
+{
+	uint32_t reg;
+
+	/* switch pin PL2,4,6 to GPIO OUT */
+	reg = mmio_read_32(R_PIO_BASE + 0x0);
+	mmio_write_32(R_PIO_BASE + 0x0, (reg & ~0xf0f0f00) | 0x1010100);
+
+	/* set PL2,4,6 value to 1 */
+	reg = mmio_read_32(R_PIO_BASE + 0x10);
+	mmio_write_32(R_PIO_BASE + 0x10, (reg & ~0x54) | 0x54);
+
+	/* level 0 drive strength */
+	reg = mmio_read_32(R_PIO_BASE + 0x14);
+	mmio_write_32(R_PIO_BASE + 0x14, (reg & ~0x3330) | 0x0);
+
+	/* set all ports to pull-disabled */
+	reg = mmio_read_32(R_PIO_BASE + 0x1c);
+	mmio_write_32(R_PIO_BASE + 0x1c, (reg & ~0x3330) | 0x0);
+}

--- a/plat/sun50iw1p1/sunxi_power.c
+++ b/plat/sun50iw1p1/sunxi_power.c
@@ -236,22 +236,25 @@ static int pmic_setup(void)
 	}
 
 	ret = sunxi_pmic_read(0x12);
-	if ((ret & 0x3f) != 0x01) {
+	if ((ret & 0x37) != 0x01) {
 		NOTICE("PMIC: Output power control 2 is an unexpected 0x%x\n",
 		       ret);
 		return -3;
 	}
 
-	if ((ret & 0xc1) != 0xc1) {
-		/* Enable DC1SW to power PHY and DLDO4 for WiFi */
-		ret = sunxi_pmic_write(0x12, ret | 0xc0);
+	if ((ret & 0xc9) != 0xc9) {
+		/* Enable DC1SW to power PHY, DLDO4 for WiFi and DLDO1 for HDMI */
+		ret = sunxi_pmic_write(0x12, ret | 0xc8);
 		if (ret < 0) {
-			NOTICE("PMIC: error %d enabling DC1SW/DLDO4\n", ret);
+			NOTICE("PMIC: error %d enabling DC1SW/DLDO4/DLDO1\n", ret);
 			return -4;
 		}
 	}
 
 	sunxi_pmic_write(0x24, 0xb3);	/* DCDC5 = DDR RAM voltage = 1.5V */
+ 
+	sunxi_pmic_write(0x15, 0x1a);	/* DLDO1 = VCC3V3_HDMI voltage = 3.3V */
+	
 
 	return 0;
 }

--- a/plat/sun50iw1p1/sunxi_power.c
+++ b/plat/sun50iw1p1/sunxi_power.c
@@ -35,10 +35,6 @@
 #include "sunxi_def.h"
 #include "sunxi_private.h"
 
-#define R_PRCM_BASE	0x1f01400ULL
-#define R_TWI_BASE	0x1f02400ULL
-#define R_PIO_BASE	0x1f02c00ULL
-
 #define RSB_BASE	0x1f03400ULL
 #define RSB_CTRL	0x00
 #define RSB_CCR		0x04

--- a/plat/sun50iw1p1/sunxi_private.h
+++ b/plat/sun50iw1p1/sunxi_private.h
@@ -72,6 +72,9 @@ int sunxi_pmic_setup(void);
 int sunxi_pmic_read(uint8_t address);
 int sunxi_pmic_write(uint8_t address, uint8_t value);
 
+/* Declarations for sunxi_ext_devices.c */
+void sunxi_setup_ext_devices_a64(void);
+
 void udelay(unsigned int delay);
 int sunxi_setup_clocks(uint16_t socid);
 


### PR DESCRIPTION
(Note: two new commits added)

Enable DLDO1 for HDMI, enable PL2/4/6 for Wi-Fi, and rasie the delay time to successfully setup clock for A64.