### PR TITLE
Enable LCD power on Pinebook

### DIFF
--- a/plat/sun50iw1p1/aarch64/sunxi_common.c
+++ b/plat/sun50iw1p1/aarch64/sunxi_common.c
@@ -153,3 +153,36 @@ uint16_t sunxi_get_socid(void)
 	mmio_write_32(0x01c00024, reg & ~(1 << 15));
 	return reg >> 16;
 }
+
+struct spl_boot_file_head {
+	uint32_t  jump_instruction;
+	uint32_t  magic[2];
+	uint32_t  check_sum;
+	uint32_t  length;
+	uint8_t   spl_signature[4];
+	uint32_t  fel_script_address;
+	uint32_t  fel_uEnv_length;
+	uint32_t  offset_dt_name;
+	uint32_t  reserved1;
+	uint32_t  boot_media;
+	uint32_t  string_pool[13];
+};
+
+const char *get_dt_name(void)
+{
+	struct spl_boot_file_head *spl_head = (void *)0x10000;
+
+	if (spl_head->magic[0] != 0x4e4f4765 ||
+	    spl_head->magic[1] != 0x3054422E) {
+		NOTICE("magic0: 0x%x, magic1: 0x%x\n",
+				spl_head->magic[0], spl_head->magic[1]);
+
+		if (spl_head->magic[1] != 0x4c45462e)
+			return NULL;
+	}
+
+	if (spl_head->spl_signature[3] < 2)
+		return NULL;
+
+	return (char *)spl_head + spl_head->offset_dt_name;
+}

--- a/plat/sun50iw1p1/bl31_sunxi_setup.c
+++ b/plat/sun50iw1p1/bl31_sunxi_setup.c
@@ -229,6 +229,8 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 
 }
 
+const char *get_dt_name(void);
+
 /*******************************************************************************
  * Initialize the gic, configure the CLCD and zero out variables needed by the
  * secondaries to boot up correctly.
@@ -236,6 +238,7 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 void bl31_platform_setup(void)
 {
 	uint16_t socid;
+	const char *dt_name;
 
 	/* Initialize the gic cpu and distributor interfaces */
 	arm_gic_init(GICC_BASE, GICD_BASE, 0, NULL, 0);
@@ -243,12 +246,19 @@ void bl31_platform_setup(void)
 
 	socid = sunxi_get_socid();
 
+	dt_name = get_dt_name();
+
+	if (dt_name)
+		NOTICE("DT: \"%s\"\n", dt_name);
+	else
+		NOTICE("No DT name found, cannot identify board.\n");
+
 	/* Detect if this SoC is a multi-cluster one. */
 	plat_setup_topology();
 
 	switch (socid) {
 	case 0x1689:
-		sunxi_pmic_setup();
+		sunxi_pmic_setup(dt_name);
 		break;
 	case 0x1718:
 		break;

--- a/plat/sun50iw1p1/sunxi_power.c
+++ b/plat/sun50iw1p1/sunxi_power.c
@@ -266,6 +266,16 @@ static int pmic_setup(const char *dt_name)
 			sunxi_pmic_write(0x24, 0x2c);
 		}
 	}
+
+	if (!strcmp(dt_name, "sun50i-a64-pinebook")) {
+		sunxi_pmic_write(0x16, 0x12); /* DLDO2 = VCC-MIPI = 2.5V */
+		ret = sunxi_pmic_read(0x12);
+		sunxi_pmic_write(0x12, ret | 0x10);
+
+		sunxi_pmic_write(0x1c, 0x0a); /* FLDO1 = HSIC = 1.2V */
+		ret = sunxi_pmic_read(0x13);
+		sunxi_pmic_write(0x13, ret | 0x4);
+	}
  
 	sunxi_pmic_write(0x15, 0x1a);	/* DLDO1 = VCC3V3_HDMI voltage = 3.3V */
 

--- a/plat/sun50iw1p1/sunxi_private.h
+++ b/plat/sun50iw1p1/sunxi_private.h
@@ -68,7 +68,7 @@ void sunxi_io_setup(void);
 void sunxi_security_setup(void);
 
 /* Declarations for sunxi_power.c */
-int sunxi_pmic_setup(void);
+int sunxi_pmic_setup(const char *dt_name);
 int sunxi_pmic_read(uint8_t address);
 int sunxi_pmic_write(uint8_t address, uint8_t value);
 


### PR DESCRIPTION
Please consider merging this change. Since u-boot currently lacks AXP803 driver and it's unlikely that it'll get one due to SPL size restriction, we need to enable LCD power on Pinebook in ATF.