### PR TITLE
sunxi: change maximum DRAM size to 3G

### DIFF
--- a/plat/sun50iw1p1/sunxi_def.h
+++ b/plat/sun50iw1p1/sunxi_def.h
@@ -49,7 +49,7 @@
  * sunxi memory map related constants
  ******************************************************************************/
 
-#define SUNXI_MAX_DRAM_SIZE           (2ull<<30)     /*2G*/
+#define SUNXI_MAX_DRAM_SIZE           (3ull<<30)     /*3G*/
 
 /*
  * This puts ATF into SRAM A2. The first 16KB (@0x40000) are used by the


### PR DESCRIPTION
The DRAM space allocated in A64/H5 memory map is 3G, and it's possible
to use all of it by using a memory chip bigger than 3G (so 4G chip is
used; it's wasteful, but it do enables the CPU to access more memory).

Change the maximum DRAM size to 3G, then the last 1G will be also mapped
to the virt address space.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>