### PR TITLE
sunxi: enable eDP bridge power on TERES I

### DIFF
--- a/plat/sun50iw1p1/sunxi_power.c
+++ b/plat/sun50iw1p1/sunxi_power.c
@@ -279,6 +279,19 @@ static int pmic_setup(const char *dt_name)
 
 		NOTICE("PMIC: enabled Pinebook display\n");
 	}
+
+	/* The same thing, but for TERES I */
+	if (!strcmp(dt_name, "sun50i-a64-teres-i")) {
+		sunxi_pmic_write(0x16, 0x12); /* DLDO2 = VCC-EDP-2V5 = 2.5V */
+		ret = sunxi_pmic_read(0x12);
+		sunxi_pmic_write(0x12, ret | 0x10);
+
+		sunxi_pmic_write(0x17, 0x05); /* DLDO3 = VCC-EDP-1V2 = 1.2V */
+		ret = sunxi_pmic_read(0x12);
+		sunxi_pmic_write(0x12, ret | 0x20);
+
+		NOTICE("PMIC: enabled TERES I display power\n");
+	}
  
 	sunxi_pmic_write(0x15, 0x1a);	/* DLDO1 = VCC3V3_HDMI voltage = 3.3V */
 


### PR DESCRIPTION
The TERES I DIY Laptop Kit uses the same ANX6345 eDP bridge with
Pinebook, but the 1.2V supply regulator is DLDO3 instead of FLDO1.

Setup power supplies for ANX6345 when the device is a TERES I (judged by
device tree).

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>